### PR TITLE
fix(allure): rm quickfix for reporting on failed test status

### DIFF
--- a/src/allure/askui-allure-step-reporter.ts
+++ b/src/allure/askui-allure-step-reporter.ts
@@ -75,11 +75,6 @@ export class AskUIAllureStepReporter implements Reporter {
       status,
       attachments,
     );
-    allure.currentTest.status = status;
-    if (step.error !== undefined) {
-      allure.currentTest.detailsMessage = `${step.error.name}: ${step.error.message}`;
-      allure.currentTest.detailsTrace = step.error.stack;
-    }
   }
 
   static attachVideo(webm: string) {


### PR DESCRIPTION
Does not work for test errors that are not counted towards failure or that are not the result of executing a step, e.g., a regular assertion. Also fails in before hooks were test has not been set up yet.

Proper fix in https://github.com/askui/askui/pull/556 confirming to the assertion error interface used by jest for determining failure vs. error.