### PR TITLE
XRAY step reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,15 @@ export default config;
 
 ### AskUIXRayStepReporter
 
-> ❗️ **IMPORTANT NOTE**: Due to restrictions this reporter only works when you run your workflows in serial (default for AskUI)!
+> ❗️ **IMPORTANT NOTE**: Due to restrictions this reporter only works when you run your workflows one after another (default for AskUI)!
 
 #### Enable and Configure the AskUIXRayStepReporter in `askui-helper.ts` (former `jest.setup.ts`)
 You have to do a few things in your `askui-helper.ts` (former `jest.setup.ts`) to enable the `AskUIXRayStepReporter`:
 
+> ℹ️ **NOTE**: We will try to move this into the custom `testEnvironment` we provide.
+
 1. Import the reporter
-2. Initialize the reporter outside the `beforeAll()` hook
+2. Initialize the reporter
 3. Add it to the `UiControlClient`
 4. Modify before `beforeEach()` and `afterEach()` hook to create/finish `TestEntries`
 5. Add writing the report to `afterAll()` hook
@@ -261,6 +263,8 @@ import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
   preset: 'ts-jest',
+  // This uses cjs module system
+  // Replace cjs with esm if your project uses esm
   testEnvironment: '@askui/askui-reporters/dist/cjs/xray/jest-xray-environment.js',
   setupFilesAfterEnv: ['./helpers/askui-helper.ts'],
   sandboxInjectedGlobals: [

--- a/README.md
+++ b/README.md
@@ -193,38 +193,89 @@ const config: Config.InitialOptions = {
 export default config;
 ```
 
+### AskUIXRayStepReporter
+
+> ❗️ **IMPORTANT NOTE**: Due to restrictions this reporter only works when you run your workflows in serial (default for AskUI)!
+
+#### Enable and Configure the AskUIXRayStepReporter in `jest.setup.ts`
+You have to do a few things in your `jest.setup.ts` to enable the `AskUIXRayStepReporter`:
+
+1. Import the reporter
+2. Initialize the reporter outside the `beforeAll()` hook
+3. Add it to the `UiControlClient`
+4. Modify before `beforeEach()` and `afterEach()` hook to create/finish `TestEntries`
+5. Add writing the report to `afterAll()` hook
+
+```typescript
+import { UiControlClient, UiController } from 'askui';
+
+/* 1 Import the reporter */
+import { AskUIXRayStepReporter } from '@askui/askui-reporters';
+
+...
+
+/* 2 Initialize the reporter */
+let xRayReporter = new AskUIXRayStepReporter({
+    withScreenshots: 'always',
+  });
+
+beforeAll(async () => {
+  ...
+  aui = await UiControlClient.build({
+    credentials: {
+      workspaceId: '<your workspace id>',
+      token: '<your access token>',
+    },
+    /* 3 Enable reporter */
+    reporter: xRayReporter,
+  });
+
+  await aui.connect();
+});
+
+/* 4 Create TestEntry with name of test from it-block */
+beforeEach(async () => {
+  xRayReporter.createNewTestEntry(global.testName);
+});
+
+/* 4 Finish TestEntry with the test status */
+afterEach(async () => {
+  xRayReporter.finishTestEntry(global.testStatus);
+});
+
+afterAll(async () => {
+  /* 5 Writing the report */
+  await xRayReporter.writeReport();
+  aui.disconnect();
+  await uiController.stop();
+});
+
+export { aui };
+```
+
+#### Configure `jest-xray-environment` in `jest.config.ts`
+For the `AskUIXRayStepReporter` step reporter to work properly you need a special `testEnvironment` that provides the names from the `it`-blocks used to create the JSON-Objects for each test. Configure the `testEnvironment` in your `jest.config.ts` as shown in the code below:
+
+```typescript
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  testEnvironment: '@askui/askui-reporters/dist/cjs/xray/jest-xray-environment.js',
+  setupFilesAfterEnv: ['./helpers/askui-helper.ts'],
+  sandboxInjectedGlobals: [
+    'Math',
+  ],
+  reporters: [ "default", "jest-junit" ]
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;
+```
+
 ### AskUIAnnotationStepReporter
 
 #### Enable and Configure the AskUIAnnotationStepReporter in `jest.setup.ts`
-
-```typescript
-import { AskUIAnnotationStepReporter, AnnotationLevel } from '@askui/askui-reporters';
-...
-  aui = await UiControlClient.build({
-    ...
-    reporter: new AskUIAnnotationStepReporter(
-        // AnnotationLevel.ON_FAILURE, /* Uncomment and change to AnnotationLevel.ALL for reporting at every step */
-        // folderPath: "report", /* Uncomment and change property for different folder */
-        // fileNameSuffix: "_testStep_annotation" /* Uncomment and change property for different file name suffix */
-      ),
-  });
-...
-```
-
-`AnnotationLevel` is implemented as an enum. You have two options:
-
-* `ON_FAILURE` (Default Value): After a step failed
-* `ALL`: After every step
-
-`folderPath` is the foldername, relative to the root of your project, the report-files will be saved to.
-
-* Default value: `report`
-
-`fileNameSuffix`: The suffix for every report-file.
-
-* The generated report-filename has the following name convention:
-** `{YYYYYYMMDDTHHmmsssss}_{passed|failed}{fileNameSuffix}.html`
-** Example: 20230922072153421_failed_testStep_annotation.html
 
 ## Enable Multiple Reporters
 You can enable multiple reporters simultaneously by passing an array of reporters in the `reporter` property like this:
@@ -247,11 +298,12 @@ aui = await UiControlClient.build({
 
 > ❗️ **IMPORTANT NOTE**: The `testEnvironment` setting has to be the __SAME__ for all reporters in the array! The following table shows which reporters can be enabled together.
 
-|                             | AskUIAllureStepReporter | AskUIJestHtmlStepReporter | AskUIAnnotationStepReporter |
-| --------------------------- | :---------------------: | :-----------------------: | :-------------------------: |
-| AskUIAllureStepReporter     |                         |          ❌               |               ❌             |
-| AskUIJestHtmlStepReporter   |         ❌              |                           |               ✅             |
-| AskUIAnnotationStepReporter |         ❌              |          ✅                |                             |
+|                             | AskUIAllureStepReporter | AskUIJestHtmlStepReporter | AskUIAnnotationStepReporter | AskUIXRayStepReporter       |
+| --------------------------- | :---------------------: | :-----------------------: | :-------------------------: | :-------------------------: |
+| AskUIAllureStepReporter     |                         |          ❌               |               ❌             |              ❌             |
+| AskUIJestHtmlStepReporter   |         ❌              |                           |               ✅             |              ✅             |
+| AskUIAnnotationStepReporter |         ❌              |          ✅                |                             |              ✅             |
+| AskUIXRayStepReporter       |         ❌              |          ✅                |              ✅             |                             |
 
 ## 📝 Implement Your Own Reporter
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Detailed examples on how to use the reporters are provided in this README.
 
 ### AskUIAllureStepReporter
 
-#### Enable Reporter in `jest.setup.ts`
+#### Enable Reporter in `askui-helper.ts` (former `jest.setup.ts`)
 
-Add the reporter to the `UiControlClient` in `jest.setup.ts`:
+Add the reporter to the `UiControlClient` in `askui-helper.ts` (former `jest.setup.ts`):
 
 ```typescript
 import { AskUIAllureStepReporter } from "@askui/askui-reporters";
@@ -62,9 +62,9 @@ You can pass a `ReporterConfig` object to the reporter to configure the level of
  */
 ```
 
-#### Configure `beforeEach()` and `afterEach()` in `jest.setup.ts`
+#### Configure `beforeEach()` and `afterEach()` in `askui-helper.ts` (former `jest.setup.ts`)
 
-The `UiControlClient` retrieves the videos and images from your `UiController`. You have to implement `beforeEach()` and `afterEach()` in `jest.setup.ts` to start the recording and then add it to your report:
+The `UiControlClient` retrieves the videos and images from your `UiController`. You have to implement `beforeEach()` and `afterEach()` in `askui-helper.ts` (former `jest.setup.ts`) to start the recording and then add it to your report:
 
 1. Allure Reporter
 
@@ -93,7 +93,7 @@ import type { Config } from "@jest/types";
 
 const config: Config.InitialOptions = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["./helper/jest.setup.ts"],
+  setupFilesAfterEnv: ["./helper/askui-helper.ts"], // former `./helper/jest.setup.ts`
   sandboxInjectedGlobals: ["Math"],
   testEnvironment: "@askui/jest-allure-circus",
 };
@@ -104,16 +104,16 @@ export default config;
 
 ### AskUIJestHtmlStepReporter
 
-> ❗️ **IMPORTANT NOTE**: Due to restrictions of `jest-html-reporters` you can either have screenshots or video with this reporter but not both at the same time. For screenshots omit the `beforeEach()` and `afterEach()` hooks in `jest.setup.ts`. For video do not configure a `reporter` in your `UiControlClient`.
+> ❗️ **IMPORTANT NOTE**: Due to restrictions of `jest-html-reporters` you can either have screenshots or video with this reporter but not both at the same time. For screenshots omit the `beforeEach()` and `afterEach()` hooks in `askui-helper.ts` (former `jest.setup.ts`). For video do not configure a `reporter` in your `UiControlClient`.
 
 #### Install `ffmpeg` On Your System
 To use this reporter you have to have [ffmpeg](http://www.ffmpeg.org/) installed on your system (including all necessary encoding libraries like `libmp3lame` or `libx264`).
 
 Please follow the [installation instructions](http://www.ffmpeg.org/download.html) for your system.
 
-#### Enable Reporter in `jest.setup.ts`
+#### Enable Reporter in `askui-helper.ts` (former `jest.setup.ts`)
 
-Add the reporter to the `UiControlClient` in `jest.setup.ts`:
+Add the reporter to the `UiControlClient` in `askui-helper.ts` (former `jest.setup.ts`):
 
 ```typescript
 // Do not forget this import at the start of the file!
@@ -153,7 +153,7 @@ You can pass a `ReporterConfig` object to the reporter to configure the level of
  */
 ```
 
-#### Configure `beforeEach()` and `afterEach()` in `jest.setup.ts`
+#### Configure `beforeEach()` and `afterEach()` in `askui-helper.ts` (former `jest.setup.ts`)
 
 ```typescript
 import path from "path";
@@ -184,7 +184,7 @@ import type { Config } from "@jest/types";
 const config: Config.InitialOptions = {
   preset: "ts-jest",
   testEnvironment: "node",
-  setupFilesAfterEnv: ["./helper/jest.setup.ts"],
+  setupFilesAfterEnv: ["./helper/askui-helper.ts"], // former `./helper/jest.setup.ts`
   sandboxInjectedGlobals: ["Math"],
   reporters: ["default", "jest-html-reporters"],
 };
@@ -197,8 +197,8 @@ export default config;
 
 > ❗️ **IMPORTANT NOTE**: Due to restrictions this reporter only works when you run your workflows in serial (default for AskUI)!
 
-#### Enable and Configure the AskUIXRayStepReporter in `jest.setup.ts`
-You have to do a few things in your `jest.setup.ts` to enable the `AskUIXRayStepReporter`:
+#### Enable and Configure the AskUIXRayStepReporter in `askui-helper.ts` (former `jest.setup.ts`)
+You have to do a few things in your `askui-helper.ts` (former `jest.setup.ts`) to enable the `AskUIXRayStepReporter`:
 
 1. Import the reporter
 2. Initialize the reporter outside the `beforeAll()` hook
@@ -275,7 +275,7 @@ export default config;
 
 ### AskUIAnnotationStepReporter
 
-#### Enable and Configure the AskUIAnnotationStepReporter in `jest.setup.ts`
+#### Enable and Configure the AskUIAnnotationStepReporter in `askui-helper.ts` (former `jest.setup.ts`)
 
 ## Enable Multiple Reporters
 You can enable multiple reporters simultaneously by passing an array of reporters in the `reporter` property like this:

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,5 +2,3 @@ export { AskUIJestHtmlStepReporter } from "./jest-html/askui-jest-html-step-repo
 export { AskUIAllureStepReporter } from "./allure/askui-allure-step-reporter";
 export { AskUIAnnotationStepReporter, AnnotationLevel } from "./annotation/askui-annotation-step-reporter";
 export { AskUIXRayStepReporter } from "./xray/askui-xray-step-reporter";
-
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
 export { AskUIJestHtmlStepReporter } from "./jest-html/askui-jest-html-step-reporter";
 export { AskUIAllureStepReporter } from "./allure/askui-allure-step-reporter";
 export { AskUIAnnotationStepReporter, AnnotationLevel } from "./annotation/askui-annotation-step-reporter";
+export { AskUIXRayStepReporter } from "./xray/askui-xray-step-reporter";
+
+

--- a/src/utils/image-reporting-utils.ts
+++ b/src/utils/image-reporting-utils.ts
@@ -1,5 +1,5 @@
 export function convertPngDataUrlToBuffer(pngDataUrl: string): Buffer {
-    const base64Data = pngDataUrl.replace(/^data:image\/png;base64,/, "");
+    const base64Data = convertPngDataUrlToBase64(pngDataUrl);
     const buffer = Buffer.from(base64Data, "base64");
     return buffer;
 }

--- a/src/utils/image-reporting-utils.ts
+++ b/src/utils/image-reporting-utils.ts
@@ -3,3 +3,8 @@ export function convertPngDataUrlToBuffer(pngDataUrl: string): Buffer {
     const buffer = Buffer.from(base64Data, "base64");
     return buffer;
 }
+
+export function convertPngDataUrlToBase64(pngDataUrl: string): string {
+    const base64Data = pngDataUrl.replace(/^data:image\/png;base64,/, "");
+    return base64Data;
+}

--- a/src/xray/askui-xray-step-reporter.ts
+++ b/src/xray/askui-xray-step-reporter.ts
@@ -26,7 +26,7 @@ type XRayEvidence = {
   contentType: string;
 }
 
-interface XRayStep {
+type XRayStep = {
   status?: Status;
   actualResult?: string;
   evidences: XRayEvidence[];

--- a/src/xray/askui-xray-step-reporter.ts
+++ b/src/xray/askui-xray-step-reporter.ts
@@ -1,0 +1,140 @@
+import { Reporter, Step, StepStatus, ReporterConfig } from "askui";
+import { convertPngDataUrlToBase64 } from "../utils/image-reporting-utils";
+import path from "path";
+import fs from "fs";
+
+/*
+ * Possible XRay status: PASS, FAIL, TODO
+ */
+enum Status {
+  PASS = "PASS",
+  FAIL = "FAIL",
+  TODO = "TODO",
+}
+
+type XRayTestObject = {
+  testKey: string;
+  status?: Status;
+  start?: string;
+  finish?: string;
+  steps?: XRayStep[];
+}
+
+type XRayEvidence = {
+  data: string;
+  filename: string;
+  contentType: string;
+}
+
+interface XRayStep {
+  status?: Status;
+  actualResult?: string;
+  evidences: XRayEvidence[];
+}
+
+function mapAskuiToXrayStepStatus(status: StepStatus): Status {
+  switch (status) {
+    case "passed":
+      return Status.PASS;
+    case "failed":
+      return Status.FAIL;
+    case "erroneous":
+      return Status.FAIL;
+    default:
+      return Status.TODO;
+  }
+}
+
+type StatusJest = "success" | "failure";
+
+function mapJestToXrayStatus(status: StatusJest): Status {
+  switch (status) {
+    case "success":
+      return Status.PASS;
+    default:
+      return Status.FAIL;
+  }
+}
+
+export class AskUIXRayStepReporter implements Reporter {
+  config?: ReporterConfig;
+  result: XRayTestObject[] = [];
+  outputDirectory: string;
+
+  constructor(config?: ReporterConfig, outputDirectory = "xray-report") {
+    if (config !== undefined) {
+      this.config = config;
+    }
+    this.outputDirectory = outputDirectory;
+  }
+
+  async createNewTestEntry(testTitle: string): Promise<void> {
+    this.result.push(
+      {
+        testKey: testTitle,
+        start: new Date().toISOString(),
+        steps: []
+      }
+    );
+  }
+
+  async finishTestEntry(testStatus: StatusJest): Promise<void> {
+    if (this.result.length > 0) {
+      const testEntry = this.result.pop();
+      if (testEntry !== undefined) {
+        testEntry.finish = new Date().toISOString();
+        testEntry.status = mapJestToXrayStatus(testStatus);
+        this.result.push(testEntry);
+      }
+    }
+  }
+
+  async onStepEnd(step: Step): Promise<void> {
+    if (this.result.length > 0) {
+      const testEntry = this.result.pop();
+      if (testEntry !== undefined) {
+        let steps = testEntry.steps;
+        if (steps === undefined) {
+          steps = [];
+        }
+        const subStep: XRayStep = {
+          status: mapAskuiToXrayStepStatus(step.status),
+          evidences: []
+        };
+
+        function createEvidence(screenshot: string) {
+          return {
+              data: convertPngDataUrlToBase64(screenshot),
+              filename: "before.png",
+              contentType: "image/png"
+            };
+        }
+
+        if (step.lastRun?.begin?.screenshot) {
+          subStep.evidences.push(
+            createEvidence(step.lastRun?.begin?.screenshot));
+        }
+
+        if (step.lastRun?.end?.screenshot) {
+          subStep.evidences.push(
+            createEvidence(step.lastRun?.end?.screenshot));
+        }
+        steps.push(subStep);
+        testEntry.steps = steps;
+        this.result.push(testEntry);
+      }
+    }
+  }
+
+  async writeReport(): Promise<void> {
+    const outputFilePath = path.join(this.outputDirectory, "report.json");
+    if (!(fs.existsSync(this.outputDirectory))) {
+      fs.mkdirSync(this.outputDirectory, { recursive: true });
+    }
+    fs.writeFileSync(
+      outputFilePath,
+      JSON.stringify({
+          tests: this.result
+        }, null, 2));
+  }
+}

--- a/src/xray/jest-xray-environment.ts
+++ b/src/xray/jest-xray-environment.ts
@@ -1,0 +1,37 @@
+import NodeEnvironment from "jest-environment-node";
+
+class JestXRayEnvironment extends NodeEnvironment {
+
+  override async setup() {
+    await super.setup();
+  }
+
+  async handleTestEvent(event: any) {
+    if (event.name === "test_start") {
+      let testNames = [];
+      let currentTest = event.test;
+
+      while (currentTest) {
+        testNames.push(currentTest.name);
+        currentTest = currentTest.parent;
+      }
+
+      if (typeof testNames[0] === 'string') {
+        testNames[0] = testNames[0].trim();
+      }
+      if (typeof testNames[1] === 'string') {
+        testNames[1] = testNames[1].trim();
+      }
+      this.global["testName"] = testNames[0]
+      this.global["describeName"] = testNames[1]
+    }
+
+    if (event.name === "test_fn_failure") {
+      this.global["testStatus"] = "failure"
+    } else if (event.name === "test_fn_success") {
+      this.global["testStatus"] = "success"
+    }
+  }
+}
+
+export { JestXRayEnvironment as default};

--- a/src/xray/jest-xray-environment.ts
+++ b/src/xray/jest-xray-environment.ts
@@ -1,4 +1,5 @@
-import NodeEnvironment from "jest-environment-node";
+import NodeEnvironment from 'jest-environment-node';
+import {Event} from 'jest-circus';
 
 class JestXRayEnvironment extends NodeEnvironment {
 
@@ -6,30 +7,21 @@ class JestXRayEnvironment extends NodeEnvironment {
     await super.setup();
   }
 
-  async handleTestEvent(event: any) {
-    if (event.name === "test_start") {
-      let testNames = [];
-      let currentTest = event.test;
+  async handleTestEvent(event: Event) {
 
-      while (currentTest) {
-        testNames.push(currentTest.name);
-        currentTest = currentTest.parent;
-      }
 
-      if (typeof testNames[0] === 'string') {
-        testNames[0] = testNames[0].trim();
-      }
-      if (typeof testNames[1] === 'string') {
-        testNames[1] = testNames[1].trim();
-      }
-      this.global["testName"] = testNames[0]
-      this.global["describeName"] = testNames[1]
+
+    if (event.name === 'test_start') {
+      this.global['testName'] = event.test.name
     }
 
-    if (event.name === "test_fn_failure") {
-      this.global["testStatus"] = "failure"
-    } else if (event.name === "test_fn_success") {
-      this.global["testStatus"] = "success"
+    switch (event.name) {
+      case 'test_fn_failure':
+        this.global['testStatus'] = 'failure';
+        break;
+      case 'test_fn_success':
+        this.global['testStatus'] = 'success';
+        break;
     }
   }
 }

--- a/src/xray/jest-xray-environment.ts
+++ b/src/xray/jest-xray-environment.ts
@@ -9,8 +9,6 @@ class JestXRayEnvironment extends NodeEnvironment {
 
   async handleTestEvent(event: Event) {
 
-
-
     if (event.name === 'test_start') {
       this.global['testName'] = event.test.name
     }

--- a/src/xray/test-entry-undefined-exception.ts
+++ b/src/xray/test-entry-undefined-exception.ts
@@ -1,0 +1,5 @@
+export class TestEntryUndefinedException extends Error {
+    constructor() {
+      super(`TestEntry can not be undefined here, because we initialised it in createNewTestEntry(). Did you run your workflow serially?`);
+    }
+  }


### PR DESCRIPTION
@adi-wan-askui 

The code works and produces a JSON that is valid according to [XRAYs Docs](https://docs.getxray.app/display/XRAYCLOUD/Using+Xray+JSON+format+to+import+execution+results#UsingXrayJSONformattoimportexecutionresults-XrayJSONSchema).

There are a few things you might want to take a look at as I am not satisfied with them:

- You have to run the workflows with `--runInBand` serially as I use an internal state of the reporter to assign the executed steps to the correct `it`-block. To remove this the step must somehow know in which `it`-block it is executed 🤔 
- The `testEnvironment` has to be configured in `jest.config.ts` like this `testEnvironment: '@askui/askui-reporters/dist/cjs/xray/jest-xray-environment.js',`. There must be a better way to do this!