### PR TITLE
feat: introduce locking for writing reports, so parallel execution does not overwrite a existing report when appending is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ let xRayReporter = new AskUIXRayStepReporter({
     },
     'xray-report', // outputDirectory (default: 'xray-report')
     false, // resetReportDirectory -> deletes the outputDirectory before execution if set to true (default: false)
-    false // appendToReport -> appends the results to the file 'report.json if set to true. Otherwise it creates files report_<timestamp>.json (default: false) 
+    false // appendToReport -> appends the results to the file 'report.json if set to true. Otherwise it creates files report_<timestamp>.json (default: false)
   );
 
 beforeAll(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,19 @@
       "dependencies": {
         "@askui/askui-jest-xray-environment": "1.0.0",
         "fluent-ffmpeg": "2.1.2",
-        "jest-html-reporters": "3.1.4"
+        "jest-html-reporters": "3.1.4",
+        "proper-lockfile": "4.1.2"
       },
       "devDependencies": {
-        "@askui/jest-allure-circus": "^1.0.22",
-        "@release-it-plugins/workspaces": "^3.2.0",
+        "@askui/jest-allure-circus": "1.0.22",
+        "@release-it-plugins/workspaces": "3.2.0",
         "@release-it/bumper": "4.0.0",
         "@release-it/conventional-changelog": "5.0.0",
         "@types/fluent-ffmpeg": "2.1.21",
         "@types/jest": "29.5.3",
         "@types/jsdom": "21.1.1",
         "@types/node": "20.4.2",
+        "@types/proper-lockfile": "4.1.4",
         "jest": "29.6.1",
         "release-it": "15.11.0",
         "sharp": "0.32.6",
@@ -2515,6 +2517,15 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -2523,6 +2534,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -10387,6 +10404,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/properties": {

--- a/package.json
+++ b/package.json
@@ -39,19 +39,21 @@
     "dist/esm/"
   ],
   "dependencies": {
+    "@askui/askui-jest-xray-environment": "1.0.0",
     "fluent-ffmpeg": "2.1.2",
     "jest-html-reporters": "3.1.4",
-    "@askui/askui-jest-xray-environment": "1.0.0"
+    "proper-lockfile": "4.1.2"
   },
   "devDependencies": {
-    "@types/fluent-ffmpeg": "2.1.21",
-    "@askui/jest-allure-circus": "^1.0.22",
-    "@release-it-plugins/workspaces": "^3.2.0",
+    "@askui/jest-allure-circus": "1.0.22",
+    "@release-it-plugins/workspaces": "3.2.0",
     "@release-it/bumper": "4.0.0",
     "@release-it/conventional-changelog": "5.0.0",
+    "@types/fluent-ffmpeg": "2.1.21",
     "@types/jest": "29.5.3",
     "@types/jsdom": "21.1.1",
     "@types/node": "20.4.2",
+    "@types/proper-lockfile": "4.1.4",
     "jest": "29.6.1",
     "release-it": "15.11.0",
     "sharp": "0.32.6",

--- a/src/xray/lock-not-aquired-exception.ts
+++ b/src/xray/lock-not-aquired-exception.ts
@@ -1,0 +1,5 @@
+export class LockNotAquiredException extends Error {
+  constructor() {
+    super(`The lock could not be acquired.`);
+  }
+}

--- a/src/xray/test-entry-undefined-exception.ts
+++ b/src/xray/test-entry-undefined-exception.ts
@@ -1,5 +1,5 @@
 export class TestEntryUndefinedException extends Error {
-    constructor() {
-      super(`TestEntry can not be undefined here, because we initialised it in createNewTestEntry(). Did you run your workflow serially?`);
-    }
+  constructor() {
+    super(`TestEntry can not be undefined here, because we initialised it in createNewTestEntry(). Did you run your workflow serially?`);
   }
+}

--- a/src/xray/writing-xray-report-exception.ts
+++ b/src/xray/writing-xray-report-exception.ts
@@ -1,0 +1,6 @@
+
+export class WritingXRayReportException extends Error {
+  constructor(reason: string) {
+    super(`Writing XRay report failed: ${reason}`);
+  }
+}


### PR DESCRIPTION
* Locking only is done when `appendToReport` is set to `true`
* Resetting the report directory is still not thread-safe. To make it thread-safe we have to come up with a strategy to lock a newly created directory in a reliable way.